### PR TITLE
Fix: mariadb needs root@"IP" to access database in container

### DIFF
--- a/backup-docker-mysql.sh
+++ b/backup-docker-mysql.sh
@@ -71,8 +71,10 @@ for i in $CONTAINER; do
 				$i /usr/bin/mysqldump -u root $MYSQL_DATABASE | gzip > $BACKUPDIR/$i-$MYSQL_DATABASE-$TIMESTAMP.sql.gz
 		done		
 	elif docker exec $i test -e /usr/bin/mariadb-dump; then
-	    # Get a list of databases in the container
-    	DATABASES=$(docker exec -e MYSQL_PWD=$MYSQL_PWD $i mariadb -uroot -s -e "show databases" | grep -Ev "(Database|information_schema|performance_schema|mysql)")
+	    # Get the IP of the DB-Container
+        IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $i);
+        # Get a list of databases in the container
+		DATABASES=$(docker exec -e MYSQL_PWD=$MYSQL_PWD $i mariadb -uroot -h $IP -s -e "show databases" | grep -Ev "(Database|information_schema|performance_schema|mysql)")
     	# Loop through each database and create a backup
     	for MYSQL_DATABASE in $DATABASES; do
 			# Start Backup


### PR DESCRIPTION
As i got access denied with your script for a Backup of paperless-mariadb i found this from https://stackoverflow.com/questions/61950105/docker-doesnt-set-mariadb-password :

MySQL user is defined by username and host that request come from. For example, there is three different user root@192.168.0.123, root@localhost and wildcard root@%.

If you set MYSQL_ROOT_PASSWORD env in docker-compose file, your mariadb will set password for user root@%, not password for user root@localhost.

But when you try to test password of mariadb, you use sudo docker exec -it docker_db_1 mysql -u root -p command, it mean mariadb-client in container will use user root@local (without password) to access mariadb-server, not user root@%(that have password you set before).

So if you want to test password you set for that user, use that command:

docker run -it mariadb mysql -u root -h MARIADB-CONTAINER-IP -p